### PR TITLE
Revise the IP solver interface code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ optimal feedback arc set, a lower bound on the smallest feedback arc
 set is returned together with the best solution found. See the
 docstring for keyword arguments and return values.
 
+### IP solvers
+
+The exact algorithm require an IP solver. Currently supported options
+are to use CBC or HiGHS directly, or any solver available in JuMP.
+For the latter the backend optimizer must be passed as a
+`solver_option`. Examples:
+```
+find_feedback_arc_set(graph; solver = "cbc")
+find_feedback_arc_set(graph; solver = "jump",
+                      solver_options = Dict("optimizer" => HiGHS.Optimizer))
+```
+
 ## Heuristic Algorithms
 
 These all work with a directed graph from the `Graphs` package and
@@ -77,20 +89,11 @@ graphs can be handled than in the Baharev benchmarks. Use the
 
 ## TODO
 
-* Make it configurable whether self-loops should be an error, ignored,
-  or included in the feedback arc set.
-
 * Register in the General registry.
-
-* Handle non-optimal solutions from the IP solver.
 
 * Add option to use LP instead of IP for non-optimal search.
 
 * Add support for weighted edges.
-
-* Generalize to other solvers than Cbc. This should be more or less
-  straightforward, but is at the moment hindered by an absence of
-  licenses for commercial solvers like Gurobi or CPLEX.
 
 ## References
 

--- a/src/FeedbackArcSets.jl
+++ b/src/FeedbackArcSets.jl
@@ -82,6 +82,14 @@ solution.
 * `solver`: IP solver. Currently `"cbc"` (default) and `"highs"` are
   supported.
 
+* `solver_options`: Dictionary of options passed to the IP solver.
+  These are specific to the solver and override settings used by the
+  algorithm. In particular setting gaps can interfere with the
+  convergence of the search in non-obvious ways and setting time
+  limits can interfere with the time management.
+  When using the `jump` solver, the backend optimizer must be passed
+  with the `"optimizer"` key.
+
 * `solver_time_limit`: Maximum time to spend in each iteration to
   solve integer programs. This will be gradually increased if the IP
   solver does not find a useful solution in the allowed time. Defaults
@@ -141,9 +149,7 @@ function find_feedback_arc_set_ip(graph::EdgeSubGraph;
                                   max_iterations = typemax(Int),
                                   time_limit = typemax(Int),
                                   solver = "cbc",
-                                  solver_options = Dict(
-                                    "allowableGap" => 0,
-                                    "relativeGap" => 0),
+                                  solver_options = Dict{String, Any}(),
                                   solver_time_limit = 10,
                                   log_level = 1,
                                   iteration_callback = print_iteration_data)
@@ -172,12 +178,8 @@ function find_feedback_arc_set_ip(graph::EdgeSubGraph;
             break
         end
 
-        solution = solve_IP(O; solver,
-                            solver_options = merge(Dict(solver_options),
-                                Dict(
-                                    "seconds" => solver_time,
-                                    "logLevel" => max(0, log_level - 1)),
-                                ))
+        solution = solve_IP(O; solver, solver_options, solver_time,
+                            log_level = log_level - 1)
         
         objbound = solution.attrs[:objbound]
 

--- a/src/cbc.jl
+++ b/src/cbc.jl
@@ -2,10 +2,13 @@ import Clp
 import Cbc
 
 function solve_IP(::Val{:cbc}, O::OptProblem, initial_solution = Int[],
-                  use_warmstart = true; options...)
+                  use_warmstart = true; solver_options, solver_time, log_level)
     model = Cbc.Cbc_newModel()
-    Cbc.Cbc_setParameter(model, "logLevel", "0")
-    for (name, value) in options
+    Cbc.Cbc_setParameter(model, "logLevel", string(max(0, log_level)))
+    Cbc.Cbc_setParameter(model, "seconds", string(solver_time))
+    Cbc.Cbc_setParameter(model, "allowableGap", "0")
+
+    for (name, value) in solver_options
         Cbc.Cbc_setParameter(model, string(name), string(value))
     end
 

--- a/src/highs.jl
+++ b/src/highs.jl
@@ -5,18 +5,14 @@ using HiGHS: Highs_create, Highs_setStringOptionValue, Highs_setSolution,
              Highs_getModelStatus, HighsInt
 
 function solve_IP(::Val{:highs}, O::OptProblem, initial_solution = Int[],
-                  use_warmstart = true; solver_options, options...)
+                  use_warmstart = true; solver_options, solver_time, log_level)
     model = Highs_create()
+    Highs_setStringOptionValue(model, "time_limit", string(solver_time))
+    Highs_setStringOptionValue(model, "mip_abs_gap", "0")
+    Highs_setStringOptionValue(model, "mip_rel_gap", "0")
+    Highs_setStringOptionValue(model, "log_to_console", string(log_level > 0))
+
     for (name, value) in solver_options
-        name = get(Dict("seconds" => "time_limit",
-                        "allowableGap" => "mip_abs_gap",
-                        "relativeGap"  => "mip_rel_gap",
-                        ),
-                   name, name)
-        if name == "logLevel"
-            name = "log_to_console"
-            value = value > 0
-        end
         Highs_setStringOptionValue(model, string(name), string(value))
     end
 

--- a/src/optimization.jl
+++ b/src/optimization.jl
@@ -34,10 +34,11 @@ mutable struct Solution
     attrs
 end
 
-function solve_IP(O::OptProblem; solver, solver_options, initial_solution = Int[],
-                  use_warmstart = true, options...)
-    solve_IP(Val(Symbol(solver)), O, initial_solution, use_warmstart;
-             solver_options, options...)
+function solve_IP(O::OptProblem; solver, solver_options,
+                  initial_solution = Int[], use_warmstart = true,
+                  solver_time, log_level)
+    solve_IP(Val(Symbol(lowercase(solver))), O, initial_solution, use_warmstart;
+             solver_options, solver_time, log_level)
 end
 
 function solve_IP(solver::Val{T}, args...; kwargs...) where T


### PR DESCRIPTION
* Repair the CBC backend. (It tried to pass `"solver_options"` literally to CBC.)
* Don't `pop!` from `solver_options`; it mutates the caller's variable. If the caller tries to use it for a second call without recreating it, it won't work the same.
* Set the algorithm controlled solver attributes directly instead of having them as a default for `solver_options`, which could easily get lost when that is customized. It's still possible to override them with explicit `solver_options`.
* Get rid of the name conversions and send all `solver_options` as raw solver attributes.
* Test the JuMP backend.
* Document the JuMP backend and `solver_options`.
